### PR TITLE
Add a new widget and a new feature

### DIFF
--- a/maliang/standard/features.py
+++ b/maliang/standard/features.py
@@ -98,6 +98,30 @@ class ButtonFeature(virtual.Feature):
         return flag
 
 
+class IconOnlyFeature(ButtonFeature):
+    """Feature of Icon Only Button"""
+
+    def _motion(self, event: tkinter.Event) -> bool:
+        if flag := self.widget.images[0].detect(event.x, event.y):
+            cursor = utility.fix_cursor(
+                "disabled" if self.widget.state == "disabled" else "hand2")
+            self.widget.master.trigger_config.update(cursor=cursor)
+            if self.widget.state == "normal":
+                self.widget.update("hover")
+        else:
+            if self.widget.state != "normal":
+                self.widget.update("normal")
+        return flag
+
+    def _button_release_1(self, event: tkinter.Event) -> bool:
+        if flag := self.widget.images[0].detect(event.x, event.y):
+            if self.widget.state == "active":
+                self.widget.update("hover")
+                if self.command is not None:
+                    self.command(*self._args)
+        return flag
+
+
 class Underline(ButtonFeature):
     """Feature of underline"""
 

--- a/maliang/standard/widgets.py
+++ b/maliang/standard/widgets.py
@@ -970,6 +970,57 @@ class IconButton(virtual.Widget):
         return self.texts[0].set(text)
 
 
+class IconOnlyButton(IconButton):
+    """A button with nothing but an icon"""
+
+    def __init__(
+        self,
+        master: containers.Canvas | virtual.Widget,
+        position: tuple[int, int],
+        size: tuple[int, int] | None = None,
+        *,
+        command: collections.abc.Callable | None = None,
+        image: enhanced.PhotoImage | None = None,
+        borderless=True,
+        anchor: typing.Literal["n", "e", "w", "s", "nw", "ne", "sw", "se", "center"] = "nw",
+        capture_events: bool | None = None,
+        gradient_animation: bool | None = None,
+        auto_update: bool | None = None,
+        style: type[virtual.Style] | None = None,
+    ) -> None:
+        """
+        * `master`: parent canvas
+        * `position`: position of the widget
+        * `size`: size of the widget
+        * `command`: a function that is triggered when the button is pressed
+        * `image`: image of the widget
+        * `anchor`: anchor of the widget
+        * `capture_events`: wether detect another widget under the widget
+        * `gradient_animation`: wether enable gradient_animation
+        * `auto_update`: whether the theme manager update it automatically
+        * `style`: style of the widget
+        """
+        if size is None:
+            size = image.width(), image.height()
+        virtual.Widget.__init__(
+            self, master, position, size, anchor=anchor,
+            capture_events=capture_events, gradient_animation=gradient_animation,
+            auto_update=auto_update, style=style)
+        if style is None:
+            self.style = styles.TextStyle(self) if borderless else styles.IconButtonStyle(self)
+        if image is not None:
+            images.StillImage(self, ((size[1]-size[0]) / 2, 0), image=image)
+        self.feature = features.IconOnlyFeature(self, command=command)
+
+    def get(self) -> Exception:
+        """This class has nothing to get"""
+        raise AttributeError()
+
+    def set(self, thing: None) -> Exception:
+        """This class has nothing to set"""
+        raise AttributeError()
+
+
 class Slider(virtual.Widget):
     """A slider for visually resizing values"""
 


### PR DESCRIPTION
PR Summary
----------

This change provides a new button ***IconOnlyButton***, which allows development to place a separate icon only button on the interface.
此更改提供了一个新的按钮***IconOnlyButton***，这使得开发时可以在界面上放置一个单独的纯图标按钮。
Below are examples:
以下是示例：
<img width="109" alt="image" src="https://github.com/user-attachments/assets/62e797ae-d63f-4018-9de2-524538605835" />

Extra Information
-----------------

This button is not very commonly used, but it is still very handy in some cases.
这个按钮虽然不是非常常用，但部分情况下还是非常方便的。

PR Checklist
------------

- [X] The PR doesn't duplicate another PR which is already open

- [ ] `"closes #0000"` is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
<!-- `"closes #0000"` 在 PR 描述的正文中来[链接相关议题](https://docs.github.com/zh/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->

- [X] New or changed code has been tested

- [X] When it comes to API modifications, the docstrings of related classes or functions are also modified

- [X] I have read the contribution guide and followed all the instructions
